### PR TITLE
Move the SDL declarations from MYOSGLUE.h to MYOSGLUE.c

### DIFF
--- a/src/MYOSGLUE.c
+++ b/src/MYOSGLUE.c
@@ -29,6 +29,24 @@
 
 #include "STRCONST.h"
 
+/* SDL2 window */
+SDL_Window *window;
+
+/* SDL2 renderer */
+SDL_Renderer *renderer;
+
+/* SDL2 texture */
+SDL_Texture *texture;
+
+/* SDL2 blitting rects for hw scaling 
+ * ratio correction using SDL_RenderCopy() */
+SDL_Rect src_rect;
+SDL_Rect dst_rect;
+
+/* SDL2 physical screen dimensions */
+int displayWidth;
+int displayHeight;
+
 /* --- some simple utilities --- */
 
 GLOBALPROC MyMoveBytes(anyp srcPtr, anyp destPtr, si5b byteCount)

--- a/src/MYOSGLUE.h
+++ b/src/MYOSGLUE.h
@@ -401,21 +401,3 @@ EXPORTPROC MyEvtQOutDone(void);
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_keycode.h>
-
-/* SDL2 window */
-SDL_Window *window;
-
-/* SDL2 renderer */
-SDL_Renderer *renderer;
-
-/* SDL2 texture */
-SDL_Texture *texture;
-
-/* SDL2 blitting rects for hw scaling 
- * ratio correction using SDL_RenderCopy() */
-SDL_Rect src_rect;
-SDL_Rect dst_rect;
-
-/* SDL2 physical screen dimensions */
-int displayWidth;
-int displayHeight;


### PR DESCRIPTION
This fixes building on GCC 10+ due to the MYOSGLUE.h header being included by every source file.

This fixes the following linking issue:

```
gcc "src/MINEM68K.c" -o "bld/MINEM68K.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/MYOSGLUE.c" -o "bld/MYOSGLUE.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/GLOBGLUE.c" -o "bld/GLOBGLUE.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/M68KITAB.c" -o "bld/M68KITAB.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/VIAEMDEV.c" -o "bld/VIAEMDEV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/IWMEMDEV.c" -o "bld/IWMEMDEV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/SCCEMDEV.c" -o "bld/SCCEMDEV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/RTCEMDEV.c" -o "bld/RTCEMDEV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/ROMEMDEV.c" -o "bld/ROMEMDEV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/SCSIEMDV.c" -o "bld/SCSIEMDV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/SONYEMDV.c" -o "bld/SONYEMDV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/SCRNEMDV.c" -o "bld/SCRNEMDV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/KBRDEMDV.c" -o "bld/KBRDEMDV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/SNDEMDEV.c" -o "bld/SNDEMDEV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/MOUSEMDV.c" -o "bld/MOUSEMDV.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc "src/PROGMAIN.c" -o "bld/PROGMAIN.o" -c -Wall -Wmissing-prototypes -Wno-uninitialized -Wundef -Wstrict-prototypes -Os
gcc \
	-o "minivmac" \
	bld/MINEM68K.o bld/MYOSGLUE.o bld/GLOBGLUE.o bld/M68KITAB.o bld/VIAEMDEV.o bld/IWMEMDEV.o bld/SCCEMDEV.o bld/RTCEMDEV.o bld/ROMEMDEV.o bld/SCSIEMDV.o bld/SONYEMDV.o bld/SCRNEMDV.o bld/KBRDEMDV.o bld/SNDEMDEV.o bld/MOUSEMDV.o bld/PROGMAIN.o  -lSDL2
/usr/bin/ld: bld/MYOSGLUE.o:(.bss+0x44): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/MYOSGLUE.o:(.bss+0x40): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/MYOSGLUE.o:(.bss+0x50): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/MYOSGLUE.o:(.bss+0x60): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/MYOSGLUE.o:(.bss+0x80): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/MYOSGLUE.o:(.bss+0x78): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/MYOSGLUE.o:(.bss+0x70): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/GLOBGLUE.o:(.bss+0x54): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/GLOBGLUE.o:(.bss+0x58): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/GLOBGLUE.o:(.bss+0x60): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/GLOBGLUE.o:(.bss+0x70): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/GLOBGLUE.o:(.bss+0x80): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/GLOBGLUE.o:(.bss+0x88): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/GLOBGLUE.o:(.bss+0x90): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/M68KITAB.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/M68KITAB.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/M68KITAB.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/M68KITAB.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/M68KITAB.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/M68KITAB.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/M68KITAB.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/VIAEMDEV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/VIAEMDEV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/VIAEMDEV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/VIAEMDEV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/VIAEMDEV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/VIAEMDEV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/VIAEMDEV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/IWMEMDEV.o:(.bss+0x8): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/IWMEMDEV.o:(.bss+0xc): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/IWMEMDEV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/IWMEMDEV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/IWMEMDEV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/IWMEMDEV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/IWMEMDEV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/SCCEMDEV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/SCCEMDEV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/SCCEMDEV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/SCCEMDEV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/SCCEMDEV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/SCCEMDEV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/SCCEMDEV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/RTCEMDEV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/RTCEMDEV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/RTCEMDEV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/RTCEMDEV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/RTCEMDEV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/RTCEMDEV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/RTCEMDEV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/ROMEMDEV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/ROMEMDEV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/ROMEMDEV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/ROMEMDEV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/ROMEMDEV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/ROMEMDEV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/ROMEMDEV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/SCSIEMDV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/SCSIEMDV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/SCSIEMDV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/SCSIEMDV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/SCSIEMDV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/SCSIEMDV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/SCSIEMDV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/SONYEMDV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/SONYEMDV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/SONYEMDV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/SONYEMDV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/SONYEMDV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/SONYEMDV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/SONYEMDV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/SCRNEMDV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/SCRNEMDV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/SCRNEMDV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/SCRNEMDV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/SCRNEMDV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/SCRNEMDV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/SCRNEMDV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/KBRDEMDV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/KBRDEMDV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/KBRDEMDV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/KBRDEMDV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/KBRDEMDV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/KBRDEMDV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/KBRDEMDV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/SNDEMDEV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/SNDEMDEV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/SNDEMDEV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/SNDEMDEV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/SNDEMDEV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/SNDEMDEV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/SNDEMDEV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/MOUSEMDV.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/MOUSEMDV.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/MOUSEMDV.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/MOUSEMDV.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/MOUSEMDV.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/MOUSEMDV.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/MOUSEMDV.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
/usr/bin/ld: bld/PROGMAIN.o:(.bss+0x0): multiple definition of `displayHeight'; bld/MINEM68K.o:(.bss+0x0): first defined here
/usr/bin/ld: bld/PROGMAIN.o:(.bss+0x4): multiple definition of `displayWidth'; bld/MINEM68K.o:(.bss+0x4): first defined here
/usr/bin/ld: bld/PROGMAIN.o:(.bss+0x10): multiple definition of `dst_rect'; bld/MINEM68K.o:(.bss+0x10): first defined here
/usr/bin/ld: bld/PROGMAIN.o:(.bss+0x20): multiple definition of `src_rect'; bld/MINEM68K.o:(.bss+0x20): first defined here
/usr/bin/ld: bld/PROGMAIN.o:(.bss+0x30): multiple definition of `texture'; bld/MINEM68K.o:(.bss+0x30): first defined here
/usr/bin/ld: bld/PROGMAIN.o:(.bss+0x38): multiple definition of `renderer'; bld/MINEM68K.o:(.bss+0x38): first defined here
/usr/bin/ld: bld/PROGMAIN.o:(.bss+0x40): multiple definition of `window'; bld/MINEM68K.o:(.bss+0x40): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:62: minivmac] Error 1
```